### PR TITLE
refactor: align codebase with Zig best practices

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,97 +27,64 @@ pub fn build(b: *std.Build) void {
     const build_opts = b.addOptions();
     build_opts.addOption([]const u8, "log_level", log_level);
 
-    const arch_module = b.createModule(.{
-        .root_source_file = b.path("src/arch/riscv32.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    // Helper to reduce boilerplate for bare-metal modules.
+    const Mod = struct {
+        b: *std.Build,
+        target: std.Build.ResolvedTarget,
+        optimize: std.builtin.OptimizeMode,
+        fn create(self: @This(), path: []const u8) *std.Build.Module {
+            return self.b.createModule(.{
+                .root_source_file = self.b.path(path),
+                .target = self.target,
+                .optimize = self.optimize,
+            });
+        }
+    };
+    const mod = Mod{ .b = b, .target = target, .optimize = effective_optimize };
 
-    const drivers_sbi_module = b.createModule(.{
-        .root_source_file = b.path("src/drivers/sbi.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const arch_module = mod.create("src/arch/riscv32.zig");
 
-    const drivers_console_module = b.createModule(.{
-        .root_source_file = b.path("src/drivers/console.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const drivers_sbi_module = mod.create("src/drivers/sbi.zig");
+
+    const drivers_console_module = mod.create("src/drivers/console.zig");
     drivers_console_module.addImport("sbi", drivers_sbi_module);
 
     // Logger depends only on console and the build options.
-    const lib_logger_module = b.createModule(.{
-        .root_source_file = b.path("src/lib/logger.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const lib_logger_module = mod.create("src/lib/logger.zig");
     lib_logger_module.addImport("console", drivers_console_module);
     lib_logger_module.addOptions("build_options", build_opts);
 
-    const lib_panic_module = b.createModule(.{
-        .root_source_file = b.path("src/lib/panic.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const lib_panic_module = mod.create("src/lib/panic.zig");
     lib_panic_module.addImport("console", drivers_console_module);
     lib_panic_module.addImport("sbi", drivers_sbi_module);
     lib_panic_module.addImport("logger", lib_logger_module);
 
-    const mm_layout_module = b.createModule(.{
-        .root_source_file = b.path("src/mm/layout.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const mm_layout_module = mod.create("src/mm/layout.zig");
 
-    const mm_allocator_module = b.createModule(.{
-        .root_source_file = b.path("src/mm/allocator.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const mm_allocator_module = mod.create("src/mm/allocator.zig");
     mm_allocator_module.addImport("layout", mm_layout_module);
     mm_allocator_module.addImport("logger", lib_logger_module);
 
-    const lib_math_module = b.createModule(.{
-        .root_source_file = b.path("src/lib/math.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const lib_math_module = mod.create("src/lib/math.zig");
 
-    const drivers_virtio_module = b.createModule(.{
-        .root_source_file = b.path("src/drivers/virtio_blk.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const drivers_virtio_module = mod.create("src/drivers/virtio_blk.zig");
     drivers_virtio_module.addImport("logger", lib_logger_module);
     drivers_virtio_module.addImport("allocator", mm_allocator_module);
     drivers_virtio_module.addImport("layout", mm_layout_module);
     drivers_virtio_module.addImport("math", lib_math_module);
 
-    const fs_module = b.createModule(.{
-        .root_source_file = b.path("src/fs/fs.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const fs_module = mod.create("src/fs/fs.zig");
     fs_module.addImport("allocator", mm_allocator_module);
     fs_module.addImport("virtio", drivers_virtio_module);
     fs_module.addImport("logger", lib_logger_module);
     fs_module.addImport("math", lib_math_module);
 
-    const mm_paging_module = b.createModule(.{
-        .root_source_file = b.path("src/mm/paging.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const mm_paging_module = mod.create("src/mm/paging.zig");
     mm_paging_module.addImport("allocator", mm_allocator_module);
     mm_paging_module.addImport("arch", arch_module);
     mm_paging_module.addImport("logger", lib_logger_module);
 
-    const proc_process_module = b.createModule(.{
-        .root_source_file = b.path("src/proc/process.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const proc_process_module = mod.create("src/proc/process.zig");
     proc_process_module.addImport("allocator", mm_allocator_module);
     proc_process_module.addImport("paging", mm_paging_module);
     proc_process_module.addImport("layout", mm_layout_module);
@@ -125,33 +92,21 @@ pub fn build(b: *std.Build) void {
     proc_process_module.addImport("virtio", drivers_virtio_module);
     proc_process_module.addImport("logger", lib_logger_module);
 
-    const syscall_module = b.createModule(.{
-        .root_source_file = b.path("src/syscall/syscall.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const syscall_module = mod.create("src/syscall/syscall.zig");
     syscall_module.addImport("arch", arch_module);
     syscall_module.addImport("sbi", drivers_sbi_module);
     syscall_module.addImport("logger", lib_logger_module);
     syscall_module.addImport("process", proc_process_module);
     syscall_module.addImport("fs", fs_module);
 
-    const kernel_trap_module = b.createModule(.{
-        .root_source_file = b.path("src/kernel/trap.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const kernel_trap_module = mod.create("src/kernel/trap.zig");
     kernel_trap_module.addImport("arch", arch_module);
     kernel_trap_module.addImport("panic", lib_panic_module);
     kernel_trap_module.addImport("layout", mm_layout_module);
     kernel_trap_module.addImport("syscall", syscall_module);
     kernel_trap_module.addImport("logger", lib_logger_module);
 
-    const kernel_main_module = b.createModule(.{
-        .root_source_file = b.path("src/kernel/main.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const kernel_main_module = mod.create("src/kernel/main.zig");
     kernel_main_module.addImport("arch", arch_module);
     kernel_main_module.addImport("logger", lib_logger_module);
     kernel_main_module.addImport("panic", lib_panic_module);
@@ -171,11 +126,7 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(exe);
 
-    const user_module = b.createModule(.{
-        .root_source_file = b.path("src/user/main.zig"),
-        .target = target,
-        .optimize = effective_optimize,
-    });
+    const user_module = mod.create("src/user/main.zig");
     user_module.addImport("syscall", syscall_module);
 
     const user = b.addExecutable(.{

--- a/src/drivers/virtio_blk.zig
+++ b/src/drivers/virtio_blk.zig
@@ -40,6 +40,7 @@ pub const VirtIoError = error{
     NotBlockDevice,
     SectorOutOfRange,
     IoError,
+    AllocFailed,
 };
 
 const VirtIoBlkReqType = enum(u32) {
@@ -114,9 +115,9 @@ pub const VirtioBlk = struct {
         regWrite32(offset, regRead32(offset) | value);
     }
 
-    fn virtqInit(index: u32) *Virtq {
+    fn virtqInit(index: u32) VirtIoError!*Virtq {
         const pages_needed = math.alignUp(@sizeOf(Virtq), PAGE_SIZE) / PAGE_SIZE;
-        const vq_paddr = allocator.allocPages(pages_needed);
+        const vq_paddr = allocator.allocPages(pages_needed) catch return error.AllocFailed;
         const vq: *Virtq = @ptrFromInt(vq_paddr);
 
         vq.* = .{
@@ -241,14 +242,14 @@ pub const VirtioBlk = struct {
 
         regWrite32(VIRTIO_REG_PAGE_SIZE, PAGE_SIZE);
 
-        const request_vq = virtqInit(0);
+        const request_vq = try virtqInit(0);
 
         regWrite32(VIRTIO_REG_DEVICE_STATUS, VIRTIO_STATUS_DRIVER_OK);
 
         const capacity = regRead64(VIRTIO_REG_DEVICE_CONFIG) * SECTOR_SIZE;
 
         const req_pages = math.alignUp(@sizeOf(VirtioBlkReq), PAGE_SIZE) / PAGE_SIZE;
-        const req_paddr = allocator.allocPages(req_pages);
+        const req_paddr = allocator.allocPages(req_pages) catch return error.AllocFailed;
         const req: *VirtioBlkReq = @ptrFromInt(req_paddr);
 
         log.info("virtio", "capacity: {} bytes", .{capacity});
@@ -261,8 +262,9 @@ pub const VirtioBlk = struct {
         };
     }
 
-    pub fn readSector(self: *VirtioBlk, buf: [*]u8, sector: usize) VirtIoError!void {
+    pub fn readSector(self: *VirtioBlk, buf: []u8, sector: usize) VirtIoError!void {
         try self.validateSector(sector);
+        if (buf.len < SECTOR_SIZE) return error.IoError;
         log.debug("virtio", "readSector sector={}", .{sector});
 
         const req = self.req;
@@ -274,8 +276,9 @@ pub const VirtioBlk = struct {
         log.debug("virtio", "readSector sector={} done", .{sector});
     }
 
-    pub fn writeSector(self: *VirtioBlk, buf: [*]u8, sector: usize) VirtIoError!void {
+    pub fn writeSector(self: *VirtioBlk, buf: []const u8, sector: usize) VirtIoError!void {
         try self.validateSector(sector);
+        if (buf.len < SECTOR_SIZE) return error.IoError;
         log.debug("virtio", "writeSector sector={}", .{sector});
 
         const req = self.req;

--- a/src/fs/fs.zig
+++ b/src/fs/fs.zig
@@ -62,7 +62,7 @@ pub fn init(virtio_blk: *virtio.VirtioBlk) void {
     log.debug("fs", "reading {} sectors ({} bytes)", .{ DISK_SIZE / SECTOR_SIZE, DISK_SIZE });
     for (0..DISK_SIZE / SECTOR_SIZE) |sector| {
         log.debug("fs", "readSector {}", .{sector});
-        blk.readSector(disk[sector * SECTOR_SIZE ..].ptr, sector) catch |err| {
+        blk.readSector(disk[sector * SECTOR_SIZE ..][0..SECTOR_SIZE], sector) catch |err| {
             log.err("fs", "readSector {} failed: {}", .{ sector, err });
         };
     }
@@ -90,14 +90,14 @@ pub fn init(virtio_blk: *virtio.VirtioBlk) void {
         setName(&file.name, raw_name[0..copy_len]);
         file.name_len = copy_len;
 
-        const data_off = off + 512;
+        const data_off = off + SECTOR_SIZE;
         const copy_data_len = @min(filesz, file.data.len);
         @memcpy(file.data[0..copy_data_len], disk[data_off .. data_off + copy_data_len]);
-        file.size = filesz;
+        file.size = copy_data_len;
 
         log.info("fs", "loaded '{s}' ({} bytes)", .{ raw_name[0..copy_len], filesz });
 
-        off += 512 + math.alignUp(filesz, 512);
+        off += SECTOR_SIZE + math.alignUp(filesz, SECTOR_SIZE);
     }
 }
 
@@ -135,7 +135,7 @@ pub fn flush() void {
         if (!file.in_use) continue;
 
         const header: *TarHeader = @ptrCast(@alignCast(&disk[off]));
-        @memset(@as([*]u8, @ptrCast(header))[0..512], 0);
+        @memset(@as([*]u8, @ptrCast(header))[0..SECTOR_SIZE], 0);
 
         setName(&header.name, std.mem.span(@as([*:0]const u8, @ptrCast(&file.name))));
         @memcpy(header.mode[0..7], "0000644");
@@ -153,15 +153,15 @@ pub fn flush() void {
         header.magic = "ustar\x00".*;
         header.version = "00".*;
 
-        @memcpy(disk[off + 512 .. off + 512 + file.size], file.data[0..file.size]);
+        @memcpy(disk[off + SECTOR_SIZE .. off + SECTOR_SIZE + file.size], file.data[0..file.size]);
 
-        off += 512 + math.alignUp(file.size, 512);
+        off += SECTOR_SIZE + math.alignUp(file.size, SECTOR_SIZE);
         if (off >= DISK_SIZE) break;
     }
 
     // Write disk back to VirtIO
     for (0..DISK_SIZE / SECTOR_SIZE) |sector| {
-        blk.writeSector(disk[sector * SECTOR_SIZE ..].ptr, sector) catch |err| {
+        blk.writeSector(disk[sector * SECTOR_SIZE ..][0..SECTOR_SIZE], sector) catch |err| {
             log.err("fs", "flush writeSector {} failed: {}", .{ sector, err });
         };
     }

--- a/src/kernel/main.zig
+++ b/src/kernel/main.zig
@@ -44,13 +44,14 @@ export fn kernel_main() noreturn {
     log.info("kernel", "scheduler initialized", .{});
 
     // Create idle process (slot 0)
-    process.idle_proc = process.Process.create(null);
-    process.idle_proc.?.pid = 0; // Override: idle has pid=0
-    process.current_proc = process.idle_proc;
+    const idle = process.createIdle();
+    process.current_proc = idle;
     log.info("kernel", "idle process created", .{});
 
     // Create user process
-    _ = process.Process.create(user_bin);
+    _ = process.createUser(user_bin) orelse {
+        panic_lib.panic("failed to create user process", .{});
+    };
     log.info("kernel", "user process created", .{});
 
     // Yield to the scheduler; if we ever return here, all processes have exited

--- a/src/kernel/trap.zig
+++ b/src/kernel/trap.zig
@@ -14,14 +14,16 @@ export fn user_entry_log() callconv(.c) void {
 }
 
 // Global assembly for user_entry — no compiler interference with callconv(.naked).
-// USER_BASE = 0x1000000, SSTATUS_SPIE|SSTATUS_SUM = 0x40020.
+// Constants: USER_BASE (layout.zig), SSTATUS_SPIE | SSTATUS_SUM (arch.zig).
 comptime {
     asm (
         \\.global user_entry
         \\.type user_entry, @function
         \\user_entry:
+        // sepc = USER_BASE (layout.USER_BASE = 0x1000000)
         \\  li t0, 0x1000000
         \\  csrw sepc, t0
+        // sstatus = SSTATUS_SPIE | SSTATUS_SUM (0x20 | 0x40000 = 0x40020)
         \\  li t0, 0x40020
         \\  csrw sstatus, t0
         \\  call user_entry_log

--- a/src/mm/allocator.zig
+++ b/src/mm/allocator.zig
@@ -3,6 +3,11 @@ const log = @import("logger");
 
 pub const PAGE_SIZE: u32 = layout.PAGE_SIZE;
 
+pub const AllocError = error{
+    OutOfMemory,
+    InvalidPageCount,
+};
+
 var next_free_paddr: u32 = undefined;
 var end_paddr: u32 = undefined;
 
@@ -11,9 +16,9 @@ pub fn init(free_ram_start: u32) void {
     end_paddr = @intFromPtr(@extern([*]u8, .{ .name = "__free_ram_end" }));
 }
 
-pub fn allocPages(n: u32) u32 {
+pub fn allocPages(n: u32) AllocError!u32 {
     if (n == 0) {
-        @panic("Invalid page count");
+        return error.InvalidPageCount;
     }
 
     const paddr = next_free_paddr;
@@ -21,7 +26,7 @@ pub fn allocPages(n: u32) u32 {
     next_free_paddr += size;
 
     if (next_free_paddr > end_paddr) {
-        @panic("Out of memory");
+        return error.OutOfMemory;
     }
 
     const ptr: [*]u8 = @ptrFromInt(paddr);

--- a/src/mm/paging.zig
+++ b/src/mm/paging.zig
@@ -14,35 +14,40 @@ pub const PageFlags = enum(u32) {
     user = 1 << 4,
 };
 
-pub const PageTableEntry = struct {
+pub const PagingError = error{
+    UnalignedAddress,
+    NotMapped,
+};
+
+const PageTableEntry = struct {
     raw: u32,
 
-    pub fn fromPhysical(paddr: u32, flags: u32) PageTableEntry {
+    fn fromPhysical(paddr: u32, flags: u32) PageTableEntry {
         return .{ .raw = ((paddr / PAGE_SIZE) << sv32.PTE_PPN_SHIFT) | (flags & sv32.PTE_FLAGS_MASK) };
     }
 
-    pub fn isValid(self: PageTableEntry) bool {
+    fn isValid(self: PageTableEntry) bool {
         return (self.raw & @intFromEnum(PageFlags.valid)) != 0;
     }
 
-    pub fn getPhysicalAddress(self: PageTableEntry) u32 {
+    fn getPhysicalAddress(self: PageTableEntry) u32 {
         return ((self.raw >> sv32.PTE_PPN_SHIFT) & sv32.PTE_PPN_MASK) * PAGE_SIZE;
     }
 
-    pub fn getFlags(self: PageTableEntry) u32 {
+    fn getFlags(self: PageTableEntry) u32 {
         return self.raw & sv32.PTE_FLAGS_MASK;
     }
 };
 
-pub fn mapPage(table1: [*]u32, vaddr: u32, paddr: u32, flags: u32) void {
-    if (!isAligned(vaddr, PAGE_SIZE)) @panic("Unaligned virtual address");
-    if (!isAligned(paddr, PAGE_SIZE)) @panic("Unaligned physical address");
+pub fn mapPage(table1: [*]u32, vaddr: u32, paddr: u32, flags: u32) (PagingError || allocator.AllocError)!void {
+    if (!isAligned(vaddr, PAGE_SIZE)) return error.UnalignedAddress;
+    if (!isAligned(paddr, PAGE_SIZE)) return error.UnalignedAddress;
 
     const vpn1 = (vaddr >> sv32.VPN1_SHIFT) & sv32.VPN_MASK;
     var pte1 = PageTableEntry{ .raw = table1[vpn1] };
 
     if (!pte1.isValid()) {
-        const pt_paddr = allocator.allocPages(1);
+        const pt_paddr = try allocator.allocPages(1);
         pte1 = PageTableEntry.fromPhysical(pt_paddr, @intFromEnum(PageFlags.valid));
         table1[vpn1] = pte1.raw;
     }
@@ -56,13 +61,13 @@ pub fn mapPage(table1: [*]u32, vaddr: u32, paddr: u32, flags: u32) void {
     log.debug("mm", "mapPage vaddr={x} -> paddr={x}", .{ vaddr, paddr });
 }
 
-pub fn unmapPage(table1: [*]u32, vaddr: u32) void {
-    if (!isAligned(vaddr, PAGE_SIZE)) @panic("Unaligned virtual address");
+pub fn unmapPage(table1: [*]u32, vaddr: u32) PagingError!void {
+    if (!isAligned(vaddr, PAGE_SIZE)) return error.UnalignedAddress;
 
     const vpn1 = (vaddr >> sv32.VPN1_SHIFT) & sv32.VPN_MASK;
     const pte1 = PageTableEntry{ .raw = table1[vpn1] };
 
-    if (!pte1.isValid()) @panic("Page not mapped");
+    if (!pte1.isValid()) return error.NotMapped;
 
     const vpn0 = (vaddr >> sv32.VPN0_SHIFT) & sv32.VPN_MASK;
     const table0: [*]u32 = @ptrFromInt(pte1.getPhysicalAddress());

--- a/src/proc/process.zig
+++ b/src/proc/process.zig
@@ -29,6 +29,10 @@ pub const ProcessState = enum(u2) {
 };
 
 /// Process structure: matches C struct process exactly
+pub const ProcessError = error{
+    NoFreeSlot,
+};
+
 pub const Process = struct {
     pid: usize,
     state: ProcessState,
@@ -36,10 +40,9 @@ pub const Process = struct {
     stack: [STACK_SIZE / @sizeOf(u32)]u32, // u32 array ensures 4-byte alignment
     page_table: [*]u32,
 
-    /// Create a new process. Matches C create_process() exactly.
-    /// Always sets ra = user_entry in the fake context frame.
-    /// Panics if no free slots.
-    pub fn create(image: ?[]const u8) *Process {
+    /// Allocate and initialize a new process slot. `image` may be empty for an idle process.
+    /// Errors if no free slots remain or if paging/allocator operations fail.
+    pub fn create(image: []const u8) (ProcessError || paging.PagingError || allocator.AllocError)!*Process {
         // Find first free slot (search from 0, like C)
         var slot_index: usize = 0;
         var proc: ?*Process = null;
@@ -51,7 +54,7 @@ pub const Process = struct {
         }
 
         if (proc == null) {
-            @panic("no free process slots");
+            return error.NoFreeSlot;
         }
 
         const p = proc.?;
@@ -102,7 +105,7 @@ pub const Process = struct {
         const saved_sp: u32 = @intCast(frame_addr);
 
         // Allocate and populate page table
-        const pt_paddr = allocator.allocPages(1);
+        const pt_paddr = try allocator.allocPages(1);
         const pt: [*]u32 = @ptrFromInt(pt_paddr);
 
         // Map all kernel pages — identity-map kernel code/data/stack/heap
@@ -116,13 +119,13 @@ pub const Process = struct {
 
         var paddr: u32 = kernel_base;
         while (paddr < free_ram_end) : (paddr += PAGE_SIZE) {
-            paging.mapPage(pt, paddr, paddr, @intFromEnum(PageFlags.read) |
+            try paging.mapPage(pt, paddr, paddr, @intFromEnum(PageFlags.read) |
                 @intFromEnum(PageFlags.write) |
                 @intFromEnum(PageFlags.exec));
         }
 
         // Map VirtIO block device MMIO region
-        paging.mapPage(
+        try paging.mapPage(
             pt,
             virtio.VIRTIO_BLK_PADDR,
             virtio.VIRTIO_BLK_PADDR,
@@ -130,16 +133,16 @@ pub const Process = struct {
         );
 
         // Map user image pages (if provided)
-        if (image) |img| {
+        if (image.len > 0) {
             var off: usize = 0;
-            while (off < img.len) : (off += PAGE_SIZE) {
-                const page_paddr = allocator.allocPages(1);
+            while (off < image.len) : (off += PAGE_SIZE) {
+                const page_paddr = try allocator.allocPages(1);
                 const page: [*]u8 = @ptrFromInt(page_paddr);
-                const copy_len = @min(PAGE_SIZE, img.len - off);
-                @memcpy(page[0..copy_len], img[off..][0..copy_len]);
+                const copy_len = @min(PAGE_SIZE, image.len - off);
+                @memcpy(page[0..copy_len], image[off..][0..copy_len]);
 
                 const vaddr = USER_BASE + @as(u32, @intCast(off));
-                paging.mapPage(
+                try paging.mapPage(
                     pt,
                     vaddr,
                     page_paddr,
@@ -163,13 +166,33 @@ pub const Process = struct {
     }
 };
 
+/// Create idle process (slot 0, pid=0, no user image).
+/// Panics on failure because the kernel cannot function without an idle process.
+pub fn createIdle() *Process {
+    const p = Process.create(&.{}) catch |err| {
+        log.err("proc", "createIdle failed: {}", .{err});
+        @panic("failed to create idle process");
+    };
+    p.pid = 0;
+    return p;
+}
+
+/// Create a user process from a binary image.
+/// Returns null if no slots remain.
+pub fn createUser(image: []const u8) ?*Process {
+    return Process.create(image) catch |err| {
+        log.err("proc", "createUser failed: {}", .{err});
+        return null;
+    };
+}
+
 // ---------------------------------------------------------------------------
 // Global scheduler state
 // ---------------------------------------------------------------------------
 
-pub var procs: [PROCS_MAX]Process = undefined;
+var procs: [PROCS_MAX]Process = undefined;
 pub var current_proc: ?*Process = null;
-pub var idle_proc: ?*Process = null;
+var idle_proc: ?*Process = null;
 
 /// Initialize the process table (zero all slots).
 pub fn init() void {


### PR DESCRIPTION
## Summary

This PR cleans up the codebase to align with Zig best practices: explicit error handling, reduced public API surface, slice safety, and centralized constants.

### Changes

- **Error-oriented APIs**: Replaced panics in `allocator.allocPages`, `paging.mapPage/unmapPage`, `Process.create`, and `virtio_blk.zig` with explicit error unions (`AllocError`, `PagingError`, `ProcessError`, `VirtIoError`). Boot-critical callers in `kernel_main` still panic, but with informative context.

- **Process creation helpers**: Added `createIdle()` and `createUser(image)` to remove the awkward `idle_proc.?.pid = 0` mutation pattern in `kernel_main`.

- **Filesystem bounds fix**: `fs.init` now stores `file.size = copy_data_len` instead of the raw TAR `filesz`, preventing potential buffer overruns in `flush()` when files exceed `file.data.len`.

- **Slice APIs for VirtIO**: `readSector`/`writeSector` now accept slices (`[]u8` / `[]const u8`) with an explicit length guard. All `fs.zig` callers updated.

- **Centralized constants**: Replaced raw `512` values with `SECTOR_SIZE` in `fs.zig`, and added cross-referencing comments in `trap.zig` inline asm for `USER_BASE` and `SSTATUS` values.

- **Tightened public API**: Made `PageTableEntry`, `procs`, and `idle_proc` private. Only `current_proc` and intended public entry points remain exported.

- **Build script cleanup**: Added a small `Mod` helper struct to reduce repetitive `b.createModule` boilerplate in `build.zig`.

### Verification

```bash
zig fmt --check src/ build.zig  # passed
zig build                       # passed
zig build run                   # boots to user shell prompt
```