### PR TITLE
fix: CI correctness, user pointer safety, filesystem errors, and module docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,15 @@ jobs:
           -nographic \
           -serial mon:stdio \
           --no-reboot \
-          -kernel zig-out/bin/kernel.elf || true
-        echo "✓ QEMU boot test completed"
+          -kernel zig-out/bin/kernel.elf \
+          -drive id=drive0,file=disk.img,format=raw,if=none \
+          -device virtio-blk-device,drive=drive0,bus=virtio-mmio-bus.0 2>&1 | tee qemu_output.log
+        if grep -q "user: main() started" qemu_output.log; then
+          echo "✓ QEMU boot test passed"
+        else
+          echo "✗ QEMU boot test failed: expected boot message not found"
+          exit 1
+        fi
 
   code-analysis:
     name: Code Analysis
@@ -191,7 +198,7 @@ jobs:
         sudo apt-get install -y qemu-system-misc llvm
 
     - name: Build release kernel
-      run: zig build -Drelease
+      run: zig build -Doptimize=ReleaseSmall
 
     - name: Create release package
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Guidance for AI coding agents working in this repository.
 
 ## Environment Prerequisites
 
-- Zig (CI uses `0.15.2`; README states `0.15.1+`)
+- Zig (CI uses `0.15.2`; project targets `0.15.1+`)
 - QEMU with `qemu-system-riscv32`
 - LLVM tools:
   - `llvm-objcopy`
@@ -32,17 +32,19 @@ Useful local checks:
 - Zig version: `zig version`
 - QEMU version: `qemu-system-riscv32 --version`
 
-## Codebase Map (Current)
+## Codebase Map
 
-- `src/kernel` - kernel entry, trap handling, scheduler handoff
-- `src/arch` - RISC-V architecture specifics (CSR and low-level routines)
-- `src/mm` - memory layout, allocator, paging
-- `src/proc` - process structures, context switching, scheduler
-- `src/syscall` - syscall numbers, handlers, and syscall-related plumbing
-- `src/drivers` - SBI and console drivers
-- `src/lib` - formatting, panic, and small utility primitives
+- `src/kernel` - kernel entry, trap handling, syscall dispatch, root kernel context
+- `src/arch` - RISC-V architecture specifics (CSR, paging, context switch, trap frame)
+- `src/mm` - memory layout constants, bump allocator
+- `src/proc` - process structures, process table
+- `src/sched` - round-robin cooperative scheduler
+- `src/abi` - syscall number enum (shared ABI between kernel and user)
+- `src/fs` - tar-based filesystem using VirtIO block device
+- `src/drivers` - SBI, console (printf), VirtIO block driver
+- `src/lib` - compile-time-filtered logger, panic, math utilities
 - `src/linker` - linker scripts for kernel and user binaries
-- `src/user` - user-space program source
+- `src/user` - user-space shell program and library (syscall stubs, I/O helpers)
 
 ## Editing Rules For Agents
 
@@ -51,6 +53,8 @@ Useful local checks:
 - Preserve RISC-V 32-bit targeting and existing linker/build flow unless explicitly requested.
 - Do not introduce host-only libraries or OS-specific APIs into kernel/user code.
 - Prefer clear, explicit error handling; avoid hidden control flow.
+- Always validate user-provided pointers before dereferencing in syscall handlers.
+- Propagate I/O errors upward rather than silently swallowing them.
 - If behavior or workflow changes, update relevant docs (`README.md`, `ROADMAP.md`, and this file when needed).
 
 ## Validation Checklist

--- a/README.md
+++ b/README.md
@@ -12,11 +12,36 @@ pico-os is a small educational OS inspired by "Operating System in 1,000 Lines".
 
 ## Features
 
-- Boots under QEMU (riscv32)
-- SV32 paging with a basic memory allocator
+- Boots under QEMU (riscv32) with OpenSBI
+- SV32 paging with two-level page tables
+- Bump allocator for physical page allocation
 - Round-robin cooperative process scheduling
 - User mode with trap handling
-- Syscalls: write, read, yield, exit
+- Console I/O via SBI
+- VirtIO block device driver
+- Tar-based filesystem (read/write)
+- Interactive shell with file read/write commands
+
+## Syscalls
+
+| Syscall    | Number | Description                           |
+|------------|--------|---------------------------------------|
+| `write`    | 1      | Write to fd (1=stdout, 2=stderr)      |
+| `read`     | 2      | Read from fd (0=stdin)                |
+| `exit`     | 3      | Exit process with code                |
+| `yield`    | 4      | Yield CPU to scheduler                |
+| `getpid`   | 5      | Return process ID                     |
+| `readfile` | 6      | Read file from disk image             |
+| `writefile`| 7      | Write file to disk image              |
+
+## Shell Commands
+
+| Command     | Description                            |
+|-------------|----------------------------------------|
+| `hello`     | Print "Hello world from shell!"        |
+| `exit`      | Exit the shell (panics kernel)         |
+| `readfile`  | Read and print `hello.txt` from disk   |
+| `writefile` | Write "Hello from shell!" to disk      |
 
 ## Requirements
 
@@ -30,17 +55,54 @@ pico-os is a small educational OS inspired by "Operating System in 1,000 Lines".
 git clone https://github.com/botirk38/pico-os.git
 cd pico-os
 
+# Default build (ReleaseSmall)
 zig build
+
+# Run in QEMU
+zig build run
+
+# Debug build (maps to ReleaseSmall, Debug would hang without console)
+zig build -Doptimize=ReleaseSafe
+
+# Change log level
+zig build -Dlog_level=debug
+
+# Run
 zig build run
 ```
 
 ## Other useful commands
 
 ```bash
-zig fmt --check src/   # Check formatting
-zig build              # Build kernel and user binaries
-zig build run          # Run in QEMU
+zig fmt --check src/        # Check formatting
+zig build                   # Build kernel and user binaries
+zig build run               # Run in QEMU
 ```
+
+## Project Structure
+
+```
+src/
+├── abi/        # Syscall number definitions (shared ABI)
+├── arch/       # RISC-V architecture specifics (CSR, paging, context switch)
+├── drivers/    # SBI, console, VirtIO block device
+├── fs/         # Tar-based filesystem
+├── kernel/     # Entry point, trap handling, syscall dispatch, root context
+├── lib/        # Logger, panic, math utilities
+├── linker/     # Kernel and user binary linker scripts
+├── mm/         # Memory layout, bump allocator
+├── proc/       # Process structure and table
+├── sched/      # Round-robin cooperative scheduler
+└── user/       # User-space program (shell) and library (syscall stubs, I/O)
+```
+
+## Known Limitations
+
+- Bump allocator cannot free pages; exited process memory leaks.
+- Scheduling is cooperative (no timer interrupts).
+- Filesystem: max 2 files, 1024 bytes per file, no directories.
+- User pointer validation checks address range only; does not walk page tables.
+- Debug builds hang because panic machinery runs before console is ready.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,39 @@
+# Roadmap
+
+## Current Status
+
+pico-os boots under QEMU riscv32 with SV32 paging, cooperative scheduling, user-mode syscalls, VirtIO block I/O, and a small tar-backed filesystem with a shell.
+
+## Short-Term Priorities
+
+- [ ] **CI reliability** — Fail CI on QEMU boot failure (QEMU test now has proper args and output check).
+- [ ] **User pointer safety** — Range-check all user-provided addresses in syscall handlers.
+- [ ] **Filesystem error propagation** — `fs.init` and `fs.flush` return errors properly rather than silently swallowing I/O failures.
+
+## Medium-Term Improvements
+
+- [ ] **Preemptive scheduling** — Add timer interrupt support for preemptive context switching.
+- [ ] **Better memory allocator** — Replace the bump allocator with a buddy or slab allocator that supports `free()`.
+- [ ] **Process cleanup** — Reclaim page-table and user-image pages when a process exits (blocked on allocator with free).
+- [ ] **Filesystem hardening** — Tar checksum computation in `flush`, bounds-checked reads, more robust error handling.
+- [ ] **Multi-process** — Load and run multiple user programs concurrently.
+- [ ] **Signal handling** — Deliver signals (SIGKILL, SIGTERM) to user processes.
+
+## Long-Term Goals
+
+- [ ] **Multi-scheduler support** — Pluggable scheduling policies (FIFO, priority, etc.).
+- [ ] **ELF loader** — Load ELF binaries instead of flat binary images.
+- [ ] **SMP** — Boot secondary harts and distribute processes.
+- [ ] **Network driver** — VirtIO-net device support.
+- [ ] **Device tree parsing** — Discover hardware instead of hard-coded addresses.
+- [ ] **Filesystem write-back cache** — Avoid writing every sector on every flush.
+- [ ] **RISC-V 64-bit support** — Build option for RV64 with Sv39 paging.
+
+## Known Limitations
+
+- Bump allocator: no free; process memory is never reclaimed.
+- No timer interrupts; scheduling is purely cooperative.
+- Filesystem: max 2 files, 1024-byte data per file, no directories.
+- User pointer validation checks address range only, not page-table permissions.
+- CI QEMU test runs on Ubuntu only (macOS job builds only).
+

--- a/build.zig
+++ b/build.zig
@@ -117,6 +117,7 @@ pub fn build(b: *std.Build) void {
     kernel_syscall_module.addImport("fs", fs_module);
     kernel_syscall_module.addImport("sbi", drivers_sbi_module);
     kernel_syscall_module.addImport("logger", lib_logger_module);
+    kernel_syscall_module.addImport("layout", mm_layout_module);
 
     const kernel_trap_module = mod.create("src/kernel/trap.zig");
     kernel_trap_module.addImport("arch", arch_module);

--- a/src/abi/AGENTS.md
+++ b/src/abi/AGENTS.md
@@ -1,0 +1,5 @@
+# abi — Agent Guidance
+
+- The enum is non-exhaustive (`_`) to allow future extension without breaking existing switch statements.
+- Both `kernel/syscall.zig` and `user/lib/syscall.zig` import this module by name `abi`.
+- Adding a syscall: add a variant here, a handler in `kernel/syscall.zig`, and a stub in `user/lib/syscall.zig`.

--- a/src/abi/README.md
+++ b/src/abi/README.md
@@ -1,0 +1,13 @@
+# abi — Syscall Number Definitions
+
+Shared ABI between kernel and user space. Defines the `Syscall` enum with numeric values.
+
+| Syscall    | Value |
+|------------|-------|
+| `write`    | 1     |
+| `read`     | 2     |
+| `exit`     | 3     |
+| `yield`    | 4     |
+| `getpid`   | 5     |
+| `readfile` | 6     |
+| `writefile`| 7     |

--- a/src/arch/AGENTS.md
+++ b/src/arch/AGENTS.md
@@ -1,0 +1,6 @@
+# arch — Agent Guidance
+
+- The `interface.zig` module validates that `riscv32.zig` exports all required symbols.
+- Assembly routines (`switch_context`, `kernelEntry`, `boot`) are in `comptime` blocks.
+- Paging map/unmap allocates intermediate page tables via `allocator.allocPages`.
+- Adding a new architecture: implement the interface and add an `arch_path` entry in `build.zig`.

--- a/src/arch/README.md
+++ b/src/arch/README.md
@@ -1,0 +1,10 @@
+# arch — RISC-V Architecture Layer
+
+Architecture-specific implementations for RISC-V 32-bit: CSR access, SV32 paging, context switching, trap frame, and the boot entry point.
+
+Key types:
+- `Word` — u32 alias.
+- `VAddr`, `PAddr` — typed virtual/physical addresses.
+- `TrapFrame` — saved register state on trap entry.
+- `Paging` — `map`, `unmap`, `Root` for page table operations.
+- `Context` — `swap` and `activateAddressSpace` for process switching.

--- a/src/drivers/AGENTS.md
+++ b/src/drivers/AGENTS.md
@@ -1,0 +1,5 @@
+# drivers — Agent Guidance
+
+- SBI functions use `ecall`; the kernel runs in supervisor mode and delegates to machine-mode OpenSBI.
+- VirtIO uses legacy interface (version 1) with a fixed MMIO address (`VIRTIO_BLK_PADDR = 0x10001000`).
+- The console `printf` is a simple format engine; it supports `{}, {s}, {x}, {d}` but not all Zig format specifiers.

--- a/src/drivers/README.md
+++ b/src/drivers/README.md
@@ -1,0 +1,7 @@
+# drivers — Hardware Drivers
+
+Three hardware interface layers:
+
+- `sbi.zig` — SBI (Supervisor Binary Interface) calls for console I/O and system reset.
+- `console.zig` — Formatted `printf` output using SBI `putChar`.
+- `virtio_blk.zig` — VirtIO block device driver using legacy MMIO interface with descriptor rings.

--- a/src/fs/AGENTS.md
+++ b/src/fs/AGENTS.md
@@ -1,0 +1,6 @@
+# fs — Agent Guidance
+
+- Filesystem init and flush now return `!void`; callers must handle I/O errors.
+- Tar checksums are computed in `computeTarChecksum` during `flush`.
+- Bounds: `FILES_MAX = 2`, file data = 1024 bytes, filename = 100 bytes.
+- The disk buffer is sized to exactly fit the file array; changing file limits requires recalculating `DISK_SIZE`.

--- a/src/fs/README.md
+++ b/src/fs/README.md
@@ -1,0 +1,8 @@
+# fs — Tar-Based Filesystem
+
+Reads and writes a simple tar-format filesystem backed by the VirtIO block device.
+
+- `init` — reads disk sectors, parses tar headers into a file array.
+- `lookup` — find a file by name.
+- `create` — add a new file entry.
+- `flush` — serializes files back into tar format and writes to disk.

--- a/src/fs/fs.zig
+++ b/src/fs/fs.zig
@@ -55,16 +55,14 @@ fn setName(dst: *[100]u8, src: []const u8) void {
     @memcpy(dst[0..len], src[0..len]);
 }
 
-pub fn init(virtio_blk: *virtio.VirtioBlk) void {
+pub fn init(virtio_blk: *virtio.VirtioBlk) !void {
     blk = virtio_blk;
 
     // Read all disk sectors into the disk buffer (matches C reference).
     log.debug("fs", "reading {} sectors ({} bytes)", .{ DISK_SIZE / SECTOR_SIZE, DISK_SIZE });
     for (0..DISK_SIZE / SECTOR_SIZE) |sector| {
         log.debug("fs", "readSector {}", .{sector});
-        blk.readSector(disk[sector * SECTOR_SIZE ..][0..SECTOR_SIZE], sector) catch |err| {
-            log.err("fs", "readSector {} failed: {}", .{ sector, err });
-        };
+        try blk.readSector(disk[sector * SECTOR_SIZE ..][0..SECTOR_SIZE], sector);
     }
 
     var off: usize = 0;
@@ -127,7 +125,15 @@ pub fn create(filename: [*:0]const u8) ?*File {
     return null;
 }
 
-pub fn flush() void {
+fn computeTarChecksum(header: *TarHeader) void {
+    @memset(header.checksum[0..8], ' ');
+    var sum: u32 = 0;
+    const bytes = @as([*]const u8, @ptrCast(header))[0..@sizeOf(TarHeader)];
+    for (bytes) |b| sum += b;
+    _ = std.fmt.bufPrint(header.checksum[0..8], "{o:0>6}\x00 ", .{sum}) catch {};
+}
+
+pub fn flush() !void {
     log.debug("fs", "flush", .{});
 
     var off: usize = 0;
@@ -148,10 +154,10 @@ pub fn flush() void {
         @memcpy(header.size[0..size_str.len], size_str);
 
         @memcpy(header.mtime[0..11], "00000000000");
-        @memcpy(header.checksum[0..8], "        ");
         header.typeflag = '0';
         header.magic = "ustar\x00".*;
         header.version = "00".*;
+        computeTarChecksum(header);
 
         @memcpy(disk[off + SECTOR_SIZE .. off + SECTOR_SIZE + file.size], file.data[0..file.size]);
 
@@ -161,8 +167,6 @@ pub fn flush() void {
 
     // Write disk back to VirtIO
     for (0..DISK_SIZE / SECTOR_SIZE) |sector| {
-        blk.writeSector(disk[sector * SECTOR_SIZE ..][0..SECTOR_SIZE], sector) catch |err| {
-            log.err("fs", "flush writeSector {} failed: {}", .{ sector, err });
-        };
+        try blk.writeSector(disk[sector * SECTOR_SIZE ..][0..SECTOR_SIZE], sector);
     }
 }

--- a/src/kernel/AGENTS.md
+++ b/src/kernel/AGENTS.md
@@ -1,0 +1,6 @@
+# kernel — Agent Guidance
+
+- `syscall.zig` dispatches by syscall number; add new cases in `dispatch()`.
+- Always validate user-provided addresses with `validateUserPtr()` before dereferencing.
+- `trap.zig` panics on unhandled traps — extend the switch cases for new exception/interrupt types.
+- The root `Context` in `context.zig` is a singleton; access via `Context.current()`.

--- a/src/kernel/README.md
+++ b/src/kernel/README.md
@@ -1,0 +1,9 @@
+# kernel — Kernel Entry, Traps, Syscalls
+
+The kernel module contains the core OS logic: boot entry, trap handling, syscall dispatch, and the root kernel context that owns the process table and scheduler.
+
+Key files:
+- `main.zig` — Boot entry (`kernel_main`), initializes subsystems, creates idle and user processes, starts scheduler.
+- `trap.zig` — Trap handler (`handleTrap`), `user_entry` assembly stub for `SRET` into user mode.
+- `syscall.zig` — Syscall dispatch table with user pointer validation.
+- `context.zig` — `Context` struct: single root context owning process table and scheduler.

--- a/src/kernel/main.zig
+++ b/src/kernel/main.zig
@@ -37,7 +37,9 @@ export fn kernel_main() noreturn {
     };
     log.info("kernel", "VirtIO initialized", .{});
 
-    fs.init(&virtio_blk_state);
+    fs.init(&virtio_blk_state) catch |err| {
+        panic_lib.panic("fs init failed: {}", .{err});
+    };
     log.info("kernel", "filesystem initialized", .{});
 
     // Initialize root kernel context

--- a/src/kernel/syscall.zig
+++ b/src/kernel/syscall.zig
@@ -4,6 +4,18 @@ const abi = @import("abi");
 const fs = @import("fs");
 const sbi = @import("sbi");
 const log = @import("logger");
+const layout = @import("layout");
+
+const USER_BASE = layout.USER_BASE;
+const USER_LIMIT: u32 = 0x1800000;
+
+fn validateUserPtr(addr: u32, len: u32) bool {
+    if (len == 0) return true;
+    const end = addr +% len;
+    if (end < addr or end > USER_LIMIT) return false;
+    if (addr < USER_BASE) return false;
+    return true;
+}
 
 pub fn dispatch(ctx: *context.Context, frame: *arch.Trap.Frame) void {
     const syscall_enum: abi.Syscall = @enumFromInt(arch.Syscall.number(frame));
@@ -49,6 +61,7 @@ fn write(frame: *arch.Trap.Frame) i32 {
     const len = arch.Syscall.arg(frame, 2);
 
     if (fd != 1 and fd != 2) return -1;
+    if (!validateUserPtr(buf, len)) return -1;
 
     const ptr: [*]const u8 = @ptrFromInt(buf);
     var i: u32 = 0;
@@ -65,6 +78,7 @@ fn read(ctx: *context.Context, frame: *arch.Trap.Frame) i32 {
 
     if (fd != 0) return -1;
     if (len == 0) return 0;
+    if (!validateUserPtr(buf, len)) return -1;
 
     const ptr: [*]u8 = @ptrFromInt(buf);
     const ch = while (true) {
@@ -93,9 +107,14 @@ fn getpid(ctx: *context.Context) u32 {
 }
 
 fn readFile(frame: *arch.Trap.Frame) i32 {
-    const filename: [*:0]const u8 = @ptrFromInt(arch.Syscall.arg(frame, 0));
-    const buf: [*]u8 = @ptrFromInt(arch.Syscall.arg(frame, 1));
+    const filename_addr = arch.Syscall.arg(frame, 0);
+    const buf_addr = arch.Syscall.arg(frame, 1);
     const len: usize = @truncate(arch.Syscall.arg(frame, 2));
+
+    if (!validateUserPtr(filename_addr, 1) or !validateUserPtr(buf_addr, @intCast(len))) return -1;
+
+    const filename: [*:0]const u8 = @ptrFromInt(filename_addr);
+    const buf: [*]u8 = @ptrFromInt(buf_addr);
 
     const file = fs.lookup(filename) orelse return -1;
     const copy_len = @min(len, file.size);
@@ -104,9 +123,14 @@ fn readFile(frame: *arch.Trap.Frame) i32 {
 }
 
 fn writeFile(frame: *arch.Trap.Frame) i32 {
-    const filename: [*:0]const u8 = @ptrFromInt(arch.Syscall.arg(frame, 0));
-    const buf: [*]const u8 = @ptrFromInt(arch.Syscall.arg(frame, 1));
+    const filename_addr = arch.Syscall.arg(frame, 0);
+    const buf_addr = arch.Syscall.arg(frame, 1);
     const len: usize = @truncate(arch.Syscall.arg(frame, 2));
+
+    if (!validateUserPtr(filename_addr, 1) or !validateUserPtr(buf_addr, @intCast(len))) return -1;
+
+    const filename: [*:0]const u8 = @ptrFromInt(filename_addr);
+    const buf: [*]const u8 = @ptrFromInt(buf_addr);
 
     const file = fs.lookup(filename) orelse fs.create(filename);
     const f = file orelse return -1;
@@ -115,7 +139,7 @@ fn writeFile(frame: *arch.Trap.Frame) i32 {
     @memcpy(f.data[0..copy_len], buf[0..copy_len]);
     f.size = copy_len;
 
-    fs.flush();
+    fs.flush() catch return -1;
 
     return @intCast(copy_len);
 }

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -1,0 +1,5 @@
+# lib — Agent Guidance
+
+- Logger uses comptime level checks; disabled-level calls compile to nothing (zero overhead).
+- `panic` calls SBI shutdown; do not import into user-space code.
+- Math functions are comptime-friendly (`alignUp` uses arithmetic, not loops).

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -1,0 +1,7 @@
+# lib — Kernel Utility Library
+
+Shared utilities used across the kernel:
+
+- `logger.zig` — Compile-time-filtered logging (err/warn/info/debug levels controlled by `-Dlog_level`).
+- `panic.zig` — Kernel panic handler.
+- `math.zig` — Math utilities (`alignUp`, `alignDown`, `min`, `max`).

--- a/src/linker/AGENTS.md
+++ b/src/linker/AGENTS.md
@@ -1,0 +1,6 @@
+# linker — Agent Guidance
+
+- Kernel stack is embedded in the kernel image (`.bss` + `128KB`).
+- Free RAM starts after the stack at a 4KB-aligned boundary.
+- The user linker assert enforces the process address space limit used by `validateUserPtr`.
+- Changing memory layout requires updating `layout.zig` and both linker scripts consistently.

--- a/src/linker/README.md
+++ b/src/linker/README.md
@@ -1,0 +1,6 @@
+# linker — Linker Scripts
+
+Linker scripts for kernel and user binaries.
+
+- `kernel.ld` — Places kernel at `0x80200000` with 128KB stack and 64MB free RAM region.
+- `user.ld` — Places user program at `0x1000000` with 64KB stack; asserts < `0x1800000`.

--- a/src/mm/AGENTS.md
+++ b/src/mm/AGENTS.md
@@ -1,0 +1,5 @@
+# mm — Agent Guidance
+
+- The bump allocator only supports allocation; calling code must not assume free is available.
+- `layout.zig` constants are imported across the kernel; changing them affects process creation, paging, and the linker script.
+- `allocator.allocPages` returns physical addresses, not pointers.

--- a/src/mm/README.md
+++ b/src/mm/README.md
@@ -1,0 +1,6 @@
+# mm — Memory Management
+
+Memory layout constants and a simple bump allocator for physical page allocation.
+
+- `layout.zig` — `PAGE_SIZE` (4096), `USER_BASE` (0x1000000), `STACK_SIZE` (8192), `KERNEL_BASE` (0x80200000).
+- `allocator.zig` — Bump allocator (`allocPages`); no `free` support.

--- a/src/proc/AGENTS.md
+++ b/src/proc/AGENTS.md
@@ -1,0 +1,6 @@
+# proc — Agent Guidance
+
+- `Process` state machine: `.unused` → `.runnable` → `.unused`.
+- `create` maps all kernel RAM and the VirtIO MMIO region for every new process (identity-mapped supervisor pages).
+- User image pages are allocated and mapped with user flags; kernel pages are supervisor-only.
+- The idle process (pid=0) has no user image and is always runnable.

--- a/src/proc/README.md
+++ b/src/proc/README.md
@@ -1,0 +1,7 @@
+# proc — Process Structures
+
+Defines the `Process` type and process `Table`.
+
+- `Process` — pid, state, saved stack pointer, kernel stack, page table pointer.
+- `Table` — fixed array of `PROCS_MAX` (8) processes; `create`, `createIdle`, `createUser`.
+- On exit, process slot resets to `.unused` for reuse. Page memory is leaked (bump allocator limitation).

--- a/src/proc/process.zig
+++ b/src/proc/process.zig
@@ -40,7 +40,15 @@ pub const Process = struct {
     }
 
     pub fn markExited(self: *Process) void {
-        self.state = .exited;
+        // Reset slot state so it can be reused by a future process.
+        // NOTE: The bump allocator cannot free pages, so the page table
+        // and user image pages allocated for this process are leaked.
+        // A proper allocator with free() support would be needed for
+        // full process cleanup.
+        self.state = .unused;
+        self.pid = 0;
+        self.sp = 0;
+        self.page_table = undefined;
     }
 
     pub fn addressSpace(self: *Process) arch.Paging.Root {

--- a/src/sched/AGENTS.md
+++ b/src/sched/AGENTS.md
@@ -1,0 +1,5 @@
+# sched — Agent Guidance
+
+- The scheduler iterates through the process table starting from the next slot after `current_pid`.
+- Changing the scheduling policy: implement a new module matching the `Scheduler` struct interface.
+- `yield` calls `arch.Context.activateAddressSpace` then `arch.Context.swap` — both must succeed atomically for correct context switching.

--- a/src/sched/README.md
+++ b/src/sched/README.md
@@ -1,0 +1,6 @@
+# sched — Round-Robin Cooperative Scheduler
+
+Simple round-robin scheduler. Owns the current and idle process pointers but not the process table.
+
+- `Scheduler.yield` — selects the next runnable process, switches address space, and swaps context.
+- Falls back to idle process when no user process is runnable.

--- a/src/user/AGENTS.md
+++ b/src/user/AGENTS.md
@@ -1,0 +1,6 @@
+# user — Agent Guidance
+
+- User code is compiled as a separate executable and embedded as a binary blob in the kernel.
+- The `start` function sets the stack pointer and jumps to `main` — no runtime init.
+- Syscall stubs must preserve the `abi.Syscall` enum values for compatibility with the kernel dispatch table.
+- I/O functions translate `\n` to `\r\n` for raw terminal mode.

--- a/src/user/README.md
+++ b/src/user/README.md
@@ -1,0 +1,7 @@
+# user — User-Space Program
+
+The user-space shell and supporting library.
+
+- `main.zig` — Interactive shell with commands: `hello`, `exit`, `readfile`, `writefile`.
+- `lib/syscall.zig` — Syscall stubs using `ecall` instruction.
+- `lib/io.zig` — I/O helpers (putchar, putstr, getchar, readline) with `\n` → `\r\n` translation.

--- a/src/user/lib/AGENTS.md
+++ b/src/user/lib/AGENTS.md
@@ -1,0 +1,5 @@
+# user/lib — Agent Guidance
+
+- The raw syscall function uses inline asm with `ecall`; register arguments follow RISC-V calling convention (a7 = number, a0–a2 = args).
+- I/O functions depend on syscall stubs; adding a new syscall requires a stub here and a handler in `kernel/syscall.zig`.
+- These modules are compiled as part of the user-space binary (`.os_tag = .freestanding`).

--- a/src/user/lib/README.md
+++ b/src/user/lib/README.md
@@ -1,0 +1,6 @@
+# user/lib — User-Space Library
+
+Support library imported by the user shell.
+
+- `syscall.zig` — Low-level syscall stubs (`write`, `read`, `exit`, `yield`, `getpid`, `readfile`, `writefile`).
+- `io.zig` — Console I/O with newline translation and line editing.


### PR DESCRIPTION
## Summary

This PR addresses all major issues identified during a comprehensive repo audit.

### CI Reliability
- QEMU boot test now includes the virtio disk drive and fails on missing output
- Release build uses proper `-Doptimize=ReleaseSmall` instead of invalid `-Drelease`

### Memory Safety
- Added `validateUserPtr` to range-check all user-provided addresses in syscall handlers (write, read, readfile, writefile)
- Validated against USER_BASE..USER_LIMIT before any pointer dereference

### Filesystem Robustness
- `fs.init` and `fs.flush` now return errors — I/O failures propagate instead of being silently swallowed
- Added proper tar checksum computation in `computeTarChecksum` during flush

### Process Lifecycle
- `markExited` resets process slot to .unused for reuse
- Documented bump-allocator memory-leak limitation

### Documentation
- Created ROADMAP.md with short/medium/long-term priorities and known limitations
- Added README.md + AGENTS.md to all 12 module directories
- Updated top-level README with full syscall table, shell commands, and project structure
- Updated AGENTS.md with new modules and validation guidance

## Verification
- `zig fmt --check src/` — passes
- `zig build` — passes (ReleaseSmall, riscv32-freestanding)
- QEMU boot test shows user shell starting successfully
